### PR TITLE
Update home bio for Prototyping.io and add projects page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -269,6 +269,44 @@ a:focus {
   margin-bottom: 1rem;
 }
 
+/* Projects page styles */
+.projects-intro {
+  font-size: 1.125rem;
+  opacity: 0.7;
+  margin-top: 1rem;
+  margin-bottom: 3rem;
+}
+
+.projects-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.project-item {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.project-title {
+  font-size: 1.875rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  opacity: 0.9;
+  transition: opacity 0.2s ease;
+}
+
+.project-item:hover .project-title {
+  opacity: 1;
+}
+
+.project-description {
+  font-size: 1.125rem;
+  opacity: 0.7;
+  line-height: 1.5;
+}
+
 /* Books page styles */
 .books-header, .thoughts-header {
   font-size: 2rem;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,20 @@
 import Image from "next/image";
-import { Github, Linkedin, Mail } from 'lucide-react'
+import { Github, Linkedin, Mail, Calendar } from 'lucide-react'
 
 export default function Home() {
   return (
     <div className="container">
       <div className="site-header">
-        <h1 className="site-title">Hey, I'm Prerit!</h1>
+        <h1 className="site-title">Hey, I&apos;m Prerit!</h1>
         <p className="site-description">
-        I live in New York and currently work as a Founding Engineer at a very early stage startup focusing on building Patient Navigation Services for the elderly. Prior to that, I was a SWE at Microsoft on the Office Security and Excel teams for 4 years and before that, I studied EECS at CU Boulder for both my undergrad and graduate degrees. I'm excited about leveraging technology to improve people's everyday lives and enjoy building high quality software that can scale quickly.
+          I&apos;m building <a href="https://www.prototyping.io/" target="_blank" rel="noopener noreferrer" className="underline">Prototyping.io</a> (YC P26), an AI-driven manufacturing platform for mechanical parts. We analyze CAD designs for manufacturability and automate production workflows so engineers can get high-quality parts faster and at lower cost.
         </p>
         <p className="site-description">
-          I love to learn how things work and am fascinated by how businesses scale from zero to millions. Outside of my nerdy musings, I like playing basketball, running and reading biographies. If you have any recs, please send them my way. My vision for a successful life entails doing meaningful work that brings me joy, surrounding myself with people who care for me while developing relationships that allow me to grow.  
+          Before this, I was a Founding Engineer at an early-stage startup building Patient Navigation Services for the elderly, and before that spent a few years at Microsoft on the Excel and Office Security teams. Earlier, I started a PhD at UIUC focused on network and storage systems (left after a year and a half) and did my undergrad and masters in EECS at CU Boulder. What ties it together is curiosity: I like working on hard problems across whatever domain I land in.
         </p>
-         <p className="site-description">
-          I'm interested in connecting with people who also enjoy: <br />
-          - Software development and engineering best practices <br />
-          - Entrepreneurship<br />
-          - Fitness & Sports<br />
-          - Reading and sharing book recommendations <br />
-          - Tools for Thoughts and creating a 2nd Brain <br />
-         </p>
+        <p className="site-description">
+          Outside of work, I&apos;m fascinated by how businesses scale to millions of users, play basketball, run, and read a lot of biographies — always taking recs. If you want to chat about hardware, manufacturing, security, or book recommendations, my inbox is open and feel free to <a href="https://calendly.com/prerit-oberai/30min" target="_blank" rel="noopener noreferrer" className="underline">schedule some time on my calendar</a>.
+        </p>
         <div className="social-links">
           <a
             href="https://github.com/PreritO"
@@ -42,6 +37,14 @@ export default function Home() {
             className="social-link"
           >
             <Mail className="social-icon" />
+          </a>
+          <a
+            href="https://calendly.com/prerit-oberai/30min"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="social-link"
+          >
+            <Calendar className="social-icon" />
           </a>
         </div>
       </div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,46 @@
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Projects | Prerit Oberai',
+}
+
+const projects = [
+  {
+    title: 'Hello Sunshine',
+    description: 'AI phone calls that deliver daily check-ins to older adults.',
+    href: 'https://www.hellocall.org/',
+  },
+  {
+    title: 'AI Sports Commentator',
+    description: 'Personalized live sports commentary that adapts to the listener. Built at the Cartesia hackathon.',
+    href: 'https://github.com/PreritO/cartesia_hackathon',
+  },
+  {
+    title: 'pycronometer',
+    description: 'Python client for the Chronometer API, for personal nutrition tracking.',
+    href: 'https://github.com/PreritO/pycronometer',
+  },
+]
+
+export default function ProjectsPage() {
+  return (
+    <div className="container">
+      <h1 className="posts-header">Projects</h1>
+      <p className="projects-intro">A selection of recent things I&apos;ve built.</p>
+      <div className="projects-list">
+        {projects.map((project) => (
+          <a
+            key={project.href}
+            href={project.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="project-item"
+          >
+            <h2 className="project-title">{project.title}</h2>
+            <p className="project-description">{project.description}</p>
+          </a>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -18,14 +18,20 @@ export default function Navbar() {
         >
           Home
         </Link>
-        <Link 
-          href="/posts" 
+        <Link
+          href="/posts"
           className={`nav-link ${pathname.startsWith('/posts') ? 'active' : ''}`}
         >
           Posts
         </Link>
-        <Link 
-          href="/books" 
+        <Link
+          href="/projects"
+          className={`nav-link ${pathname.startsWith('/projects') ? 'active' : ''}`}
+        >
+          Projects
+        </Link>
+        <Link
+          href="/books"
           className={`nav-link ${pathname.startsWith('/books') ? 'active' : ''}`}
         >
           Bookshelf


### PR DESCRIPTION
## Summary
Rebased version of the closed PR #1, applied on top of the current main (which moved to Notion-backed posts and Vercel deploys while the previous branch was open).

- **Home bio rewrite**: leads with Prototyping.io (YC P26), threads in the Patient Navigation founding-engineer role and the UIUC PhD on network/storage systems, replaces the bullet-list interests block with a friendlier closing paragraph, and ends with a Calendly invitation.
- **Calendly icon** added to the social row alongside GitHub / LinkedIn / Mail.
- **New `/projects` page** with three selected recent projects: Hello Sunshine, the Cartesia hackathon AI sports commentator, and pycronometer.
- **Navbar**: Projects link added between Posts and Bookshelf.
- **Globals CSS**: matching classes for the projects page.

## Notes
- Dropped the "I'm interested in connecting with people who also enjoy: …" bullet list that was on main. If you want to keep that, easy to restore.
- Kept the `https://github.com/PreritO` link as-is (vs the old lowercase `preritoberai` form that was on the closed PR).
- Local `npm run build` only fails because the Notion API token isn't set in my shell — TypeScript is clean and the code itself compiles. Vercel preview should build fine since it has the env vars.

## Test plan
- [ ] Vercel preview deploys successfully on this PR
- [ ] On the preview, the three home-page paragraphs render and the inline Prototyping.io + Calendly links open the right pages
- [ ] Calendar icon in the social row opens calendly.com/prerit-oberai/30min
- [ ] `/projects` loads with three entries, each opening its external URL in a new tab
- [ ] Navbar order: Home, Posts, Projects, Bookshelf, Random Thoughts — all five highlight correctly when active
- [ ] Existing `/posts`, `/books`, `/thoughts` pages still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)