### PR TITLE
Mobile layout fixes and memo-style typography

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,8 +27,9 @@
 body {
   background-color: var(--background);
   color: var(--foreground);
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  line-height: 1.5;
+  font-family: var(--font-inter), system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 1rem;
+  line-height: 1.65;
   margin: 0;
   padding: 0;
   transition: background-color 0.2s ease, color 0.2s ease;
@@ -46,16 +47,31 @@ body {
 
 .nav-links {
   display: flex;
-  gap: 2rem;
+  gap: 1.75rem;
+  flex-wrap: wrap;
 }
 
 .nav-link {
-  font-size: 1.25rem;
-  font-family: 'Times New Roman', Times, serif;
-  opacity: 0.9;
+  font-size: 1.0625rem;
+  font-family: inherit;
+  font-weight: 400;
+  opacity: 0.7;
   transition: opacity 0.2s ease;
   text-decoration: none;
   color: inherit;
+}
+
+@media (max-width: 640px) {
+  .navbar {
+    padding: 1rem 0;
+  }
+  .nav-links {
+    gap: 1rem;
+    row-gap: 0.5rem;
+  }
+  .nav-link {
+    font-size: 1rem;
+  }
 }
 
 .nav-link:hover {
@@ -64,7 +80,7 @@ body {
 
 .nav-link.active {
   opacity: 1;
-  font-weight: 700;
+  font-weight: 500;
 }
 
 .theme-toggle {
@@ -107,17 +123,28 @@ body {
 
 .site-title {
   text-align: left;
-  font-size: 2.5rem;
-  font-weight: 700;
-  margin-bottom: 1rem;
-  opacity: 0.9;
+  font-size: 2rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin-bottom: 1.5rem;
+  opacity: 0.95;
 }
 
 .site-description {
   text-align: left;
-  font-size: 1.25rem;
-  opacity: 0.9;
-  margin-bottom: 2rem;
+  font-size: 1.0625rem;
+  line-height: 1.65;
+  opacity: 0.85;
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .site-title {
+    font-size: 1.75rem;
+  }
+  .site-description {
+    font-size: 1rem;
+  }
 }
 
 .social-links {
@@ -144,15 +171,15 @@ body {
 
 /* Posts page styles */
 .posts-header {
-  font-size: 2.5rem;
-  font-weight: 700;
-  /* margin-bottom: 3rem; */
-  opacity: 0.9;
+  font-size: 2rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  opacity: 0.95;
 }
 
 .posts-list {
   flex-direction: column;
-  gap: 4rem;
+  gap: 3rem;
 }
 
 .post-item {
@@ -162,9 +189,9 @@ body {
 }
 
 .post-title {
-  font-size: 1.875rem;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
+  font-size: 1.375rem;
+  font-weight: 500;
+  margin-bottom: 0.375rem;
   opacity: 0.9;
   transition: opacity 0.2s ease;
 }
@@ -174,8 +201,17 @@ body {
 }
 
 .post-date {
-  font-size: 1.125rem;
+  font-size: 0.9375rem;
   opacity: 0.6;
+}
+
+@media (max-width: 640px) {
+  .posts-header {
+    font-size: 1.75rem;
+  }
+  .post-title {
+    font-size: 1.25rem;
+  }
 }
 
 /* Remove default purple visited state */
@@ -195,10 +231,11 @@ a:focus {
 }
 
 .post-title {
-  font-size: 2.5rem;
-  font-weight: 700;
+  font-size: 2rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
   margin-bottom: 1rem;
-  opacity: 0.9;
+  opacity: 0.95;
 }
 
 .post-meta {
@@ -247,31 +284,44 @@ a:focus {
 }
 
 .post-content {
-  font-size: 1.125rem;
-  line-height: 1.75;
+  font-size: 1.0625rem;
+  line-height: 1.7;
 }
 
 .post-content p {
-  margin-bottom: 1.5rem;
+  margin-bottom: 1.25rem;
 }
 
 .post-content h2 {
-  font-size: 1.875rem;
-  font-weight: 600;
-  margin-top: 3rem;
-  margin-bottom: 1.5rem;
-}
-
-.post-content h3 {
   font-size: 1.5rem;
-  font-weight: 600;
+  font-weight: 500;
+  letter-spacing: -0.01em;
   margin-top: 2.5rem;
   margin-bottom: 1rem;
 }
 
+.post-content h3 {
+  font-size: 1.25rem;
+  font-weight: 500;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+}
+
+@media (max-width: 640px) {
+  .post-content {
+    font-size: 1rem;
+  }
+  .post-content h2 {
+    font-size: 1.375rem;
+  }
+  .post-content h3 {
+    font-size: 1.1875rem;
+  }
+}
+
 /* Projects page styles */
 .projects-intro {
-  font-size: 1.125rem;
+  font-size: 1.0625rem;
   opacity: 0.7;
   margin-top: 1rem;
   margin-bottom: 3rem;
@@ -280,7 +330,7 @@ a:focus {
 .projects-list {
   display: flex;
   flex-direction: column;
-  gap: 3rem;
+  gap: 2.5rem;
 }
 
 .project-item {
@@ -290,9 +340,9 @@ a:focus {
 }
 
 .project-title {
-  font-size: 1.875rem;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
+  font-size: 1.375rem;
+  font-weight: 500;
+  margin-bottom: 0.375rem;
   opacity: 0.9;
   transition: opacity 0.2s ease;
 }
@@ -302,27 +352,51 @@ a:focus {
 }
 
 .project-description {
-  font-size: 1.125rem;
+  font-size: 1rem;
   opacity: 0.7;
-  line-height: 1.5;
+  line-height: 1.6;
+}
+
+@media (max-width: 640px) {
+  .projects-intro {
+    font-size: 1rem;
+  }
+  .project-title {
+    font-size: 1.25rem;
+  }
+  .project-description {
+    font-size: 0.9375rem;
+  }
 }
 
 /* Books page styles */
 .books-header, .thoughts-header {
   font-size: 2rem;
-  font-weight: 700;
+  font-weight: 500;
+  letter-spacing: -0.01em;
   margin-bottom: 1rem;
+  opacity: 0.95;
 }
 
 .books-intro, .thoughts-intro {
   color: var(--secondary);
+  font-size: 1.0625rem;
   margin-bottom: 2rem;
+}
+
+@media (max-width: 640px) {
+  .books-header, .thoughts-header {
+    font-size: 1.75rem;
+  }
+  .books-intro, .thoughts-intro {
+    font-size: 1rem;
+  }
 }
 
 .books-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 2rem;
+  grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr));
+  gap: 1.5rem;
   margin-top: 2rem;
 }
 
@@ -340,9 +414,9 @@ a:focus {
 }
 
 .book-title {
-  font-size: 1.2rem;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
+  font-size: 1.125rem;
+  font-weight: 500;
+  margin-bottom: 0.375rem;
 }
 
 .book-author {
@@ -394,7 +468,8 @@ a:focus {
 }
 
 .thought-content {
-  font-size: 1.1rem;
+  font-size: 1.0625rem;
+  line-height: 1.65;
   margin-bottom: 1rem;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,14 @@
 import type { Metadata } from "next";
+import { Inter } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import Navbar from "@/components/Navbar";
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter",
+});
 
 export const metadata: Metadata = {
   title: "Prerit Oberai",
@@ -14,13 +21,13 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" suppressHydrationWarning className="dark">
+    <html lang="en" suppressHydrationWarning className={`dark ${inter.variable}`}>
       <body className="min-h-screen font-sans antialiased">
         <ThemeProvider>
-          <div className="max-w-[650px] mx-auto px-8">
-            <div className="mt-48">
+          <div className="max-w-[650px] mx-auto px-6 sm:px-8">
+            <div className="mt-16 sm:mt-32 md:mt-48">
               <Navbar />
-              <main className="mt-32">
+              <main className="mt-12 sm:mt-20 md:mt-32">
                 {children}
               </main>
             </div>

--- a/src/components/PostsList.tsx
+++ b/src/components/PostsList.tsx
@@ -24,7 +24,7 @@ export default function PostsList({ posts, selectedTag }: PostsListProps) {
       {filteredPosts.map((post) => (
         <article key={post.slug}>
           <Link href={`/posts/${post.slug}`} className="post-item">
-            <h2 className="text-2xl font-serif opacity-90 hover:opacity-100 transition-opacity leading-tight">
+            <h2 className="post-title">
               {post.title}
             </h2>
             <time className="post-date">{new Date(post.date).toLocaleDateString()}</time>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,9 @@ const config: Config = {
   darkMode: 'class',
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['var(--font-inter)', 'ui-sans-serif', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'sans-serif'],
+      },
       colors: {
         background: 'var(--background)',
         foreground: 'var(--foreground)',


### PR DESCRIPTION
## Summary
Two related UX changes:

**Mobile layout** — the site's heavy top margins (`mt-48`, `mt-32`) and 5-item serif navbar with 2rem gaps were overflowing and pushing content way down on small screens. This PR:
- Scales top margins down responsively (`mt-16` → `mt-32` → `mt-48` from mobile to desktop)
- Allows the navbar to wrap on narrow viewports, with smaller gap, font, and padding
- Reduces page horizontal padding from `px-8` to `px-6` on mobile
- Adds `@media (max-width: 640px)` rules for headings, descriptions, post/project/book titles, post content, books grid

**Typography** — picks up the clean memo aesthetic from [natural.co/blog/agentic-payments-memo](https://www.natural.co/blog/agentic-payments-memo). They use a paid custom font (STK Miso); this PR uses **Inter** via `next/font/google` as a free, self-hosted, FOUC-free equivalent. The bigger change is the *rules*:
- Headings drop from weight 700/600 to **500** with slight negative letter-spacing
- Body text drops from `1.25rem` (20px) to `1rem` (16px) with line-height `1.65`
- Section headers (`/posts`, `/books`, `/thoughts`, `/projects`) and card titles all scale down to memo proportions
- Tailwind `sans` font stack updated to consume the Inter CSS variable so `font-sans` and the body element both pick it up
- Replaces ad-hoc Tailwind `text-2xl font-serif ...` on `PostsList` with the shared `.post-title` class so styling stays consistent across the site

## Notes
- Inter is loaded with `display: swap` so the system fallback shows immediately and Inter swaps in once loaded.
- The serif Times nav font is gone — feels off-brand against the new sans-serif body. Easy to bring back if you miss it.
- Local `npm run build` confirms compile + type checks pass cleanly (only fails later on Notion env vars I don't have locally).

## Test plan
- [ ] Vercel preview deploys successfully
- [ ] Resize the preview to ~375px wide: navbar wraps cleanly, no horizontal scroll, content has comfortable side padding
- [ ] On desktop, body text is noticeably smaller and lighter-weight; headings are no longer bold
- [ ] Inter renders (check Network tab — should see `inter-latin*.woff2` from `_next/static/media/`)
- [ ] `/posts`, `/books`, `/thoughts`, `/projects` all look consistent with the new scale
- [ ] Active nav link is still distinguishable (now weight 500 instead of 700)

🤖 Generated with [Claude Code](https://claude.com/claude-code)