### PR TITLE
Fix theme hijacking and centering regression

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,11 +46,51 @@ body {
   font-family: var(--font-inter), system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 17px;
   line-height: 1.65;
+  min-height: 100vh;
   margin: 0;
   padding: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-feature-settings: "kern", "liga", "calt";
+}
+
+/* =========================================================
+   Page wrapper — explicit centering rules so this never
+   depends on Tailwind picking up an arbitrary value.
+   ========================================================= */
+.page-wrapper {
+  max-width: 720px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  padding-top: 2.5rem;
+}
+
+@media (min-width: 640px) {
+  .page-wrapper {
+    padding-left: 2rem;
+    padding-right: 2rem;
+    padding-top: 4rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .page-wrapper {
+    padding-top: 5rem;
+  }
+}
+
+.page-main {
+  margin-top: 2.5rem;
+}
+
+@media (min-width: 640px) {
+  .page-main { margin-top: 3.5rem; }
+}
+
+@media (min-width: 768px) {
+  .page-main { margin-top: 4rem; }
 }
 
 a:visited { color: inherit; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,15 +22,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning className={inter.variable}>
-      <body className="min-h-screen font-sans antialiased">
+      <body className="antialiased">
         <ThemeProvider>
-          <div className="max-w-[720px] mx-auto px-6 sm:px-8">
-            <div className="mt-10 sm:mt-16 md:mt-20">
-              <Navbar />
-              <main className="mt-10 sm:mt-14 md:mt-16">
-                {children}
-              </main>
-            </div>
+          <div className="page-wrapper">
+            <Navbar />
+            <main className="page-main">{children}</main>
           </div>
         </ThemeProvider>
       </body>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext } from 'react'
 
 type Theme = 'light' | 'dark'
 
@@ -9,50 +9,24 @@ type ThemeContextType = {
   toggleTheme: () => void
 }
 
-const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
+const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  toggleTheme: () => {},
+})
 
+// Light-only per DESIGN.md. The provider is preserved so existing
+// `useTheme()` callers (Navbar) keep working without import changes,
+// but we no longer touch `document.documentElement.className` — that
+// was hijacking the Inter font variable from layout.tsx and forcing
+// dark mode whenever the OS preferred dark.
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('light')
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    // Get the theme from localStorage or system preference
-    const savedTheme = localStorage.getItem('theme') as Theme
-    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-
-    console.log('Initial theme setup:', { savedTheme, systemPrefersDark })
-
-    const initialTheme = savedTheme || (systemPrefersDark ? 'dark' : 'light')
-    setTheme(initialTheme)
-    document.documentElement.className = initialTheme
-    
-    setMounted(true)
-  }, [])
-
-  const toggleTheme = () => {
-    const newTheme = theme === 'light' ? 'dark' : 'light'
-    console.log('Toggling theme:', { currentTheme: theme, newTheme })
-    setTheme(newTheme)
-    localStorage.setItem('theme', newTheme)
-    document.documentElement.className = newTheme
-  }
-
-  // Prevent hydration mismatch by not rendering until mounted
-  if (!mounted) {
-    return null
-  }
-
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme: 'light', toggleTheme: () => {} }}>
       {children}
     </ThemeContext.Provider>
   )
 }
 
 export function useTheme() {
-  const context = useContext(ThemeContext)
-  if (context === undefined) {
-    throw new Error('useTheme must be used within a ThemeProvider')
-  }
-  return context
-} 
+  return useContext(ThemeContext)
+}


### PR DESCRIPTION
## Root cause

Two bugs surfaced after merging PR #5 (the design system rollout):

1. **Background read as dark and Inter wasn't loading.** `ThemeProvider`'s `useEffect` did:

   \`\`\`tsx
   document.documentElement.className = initialTheme
   \`\`\`

   That assignment **overwrites the entire `<html>` className**, which means the \`inter.variable\` className I set in \`layout.tsx\` got wiped on every mount — Inter never loads, system serif fallback kicks in. It also applies \`.dark\` whenever the user's OS prefers dark mode, which forces dark theme regardless of the design system.

2. **Content was no longer centered on desktop.** The 720px wrapper used Tailwind's arbitrary-value utility \`max-w-[720px] mx-auto\`. Whether due to a stale build or Tailwind not picking up the arbitrary value reliably, the centering didn't apply on the deployed page.

## Fix

- **\`ThemeProvider.tsx\`** — neutered to a no-op pass-through. It still exports \`ThemeProvider\` and \`useTheme\` so the existing \`Navbar\` import keeps working, but it no longer touches the DOM. Site is light-only per DESIGN.md.
- **\`layout.tsx\` + \`globals.css\`** — replaced the Tailwind \`max-w-[720px] mx-auto px-6 sm:px-8\` wrapper with an explicit \`.page-wrapper\` CSS class that centers via \`max-width: 720px; margin-left/right: auto\`. Doesn't depend on Tailwind processing arbitrary values. Responsive top-padding moved into the same class.

## Test plan
- [ ] Vercel preview deploys
- [ ] Background is the warm bone \`#faf8f2\` (not black) on desktop AND when OS prefers dark mode
- [ ] Inter font loads (network tab shows \`inter-latin\`); body reads as sans-serif
- [ ] Content is horizontally centered at 720px max-width
- [ ] Mobile (~375px): nav wraps, content has 24px side padding, no horizontal scroll
- [ ] All five pages (home, posts, projects, books, thoughts) render the new design system correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)