### PR TITLE
Fix Vercel build: wrap PostsList in Suspense

### DIFF
--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react'
 import { getAllPosts } from '@/lib/notion'
 import PostsList from '@/components/PostsList'
 import { Metadata } from 'next'
@@ -6,8 +7,9 @@ export const metadata: Metadata = {
   title: 'Posts | Prerit Oberai',
 }
 
-export const revalidate = process.env.REVALIDATION_TIME_BLOG ? 
-  parseInt(process.env.REVALIDATION_TIME_BLOG) : 3600; // Fallback to 1 hour
+export const revalidate = process.env.REVALIDATION_TIME_BLOG
+  ? parseInt(process.env.REVALIDATION_TIME_BLOG)
+  : 3600
 
 export default async function PostsPage() {
   const posts = await getAllPosts()
@@ -15,7 +17,9 @@ export default async function PostsPage() {
   return (
     <div className="container">
       <h1 className="posts-header">Posts</h1>
-      <PostsList posts={posts} />
+      <Suspense fallback={null}>
+        <PostsList posts={posts} />
+      </Suspense>
     </div>
   )
-} 
+}


### PR DESCRIPTION
## Root cause

Vercel started failing right after PR #6 merged. Production main is also failing. Same root cause for both:

\`PostsList\` uses \`useSearchParams()\`. Next.js 14 requires that hook to live inside a \`<Suspense>\` boundary at SSR/SSG time, otherwise the build errors during the static-pages phase.

**Why it only just surfaced:** the previous \`ThemeProvider\` had a \`mounted\` flag that returned \`null\` until client hydration. That meant the entire app rendered as \`null\` server-side, so \`PostsList\` never ran on the server, and the missing-Suspense bug was hidden. PR #6 neutered the provider (correctly — it was breaking theme + Inter), so descendants now render at SSR time and the latent issue surfaced.

**Why local builds didn't catch it:** local \`npm run build\` dies during "Collecting page data" because of the missing Notion token (\`API token is invalid\`). The static-pages phase — where the Suspense error fires — runs *after* that. Vercel has the Notion token, so it gets past data collection and hits the Suspense error.

## Fix

Wrap \`<PostsList>\` in \`<Suspense fallback={null}>\` inside \`src/app/posts/page.tsx\`. No behavioral change — \`PostsList\` runs the same way on the client.

## Test plan
- [ ] Vercel preview deploys cleanly on this PR
- [ ] After merge, production main goes green and the live site loads
- [ ] All five pages still render correctly (home, posts, projects, books, thoughts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)